### PR TITLE
Fixing oc login during Apply ssl cert against OpenShift step

### DIFF
--- a/.github/workflows/deploy-argocd.yml
+++ b/.github/workflows/deploy-argocd.yml
@@ -1,0 +1,57 @@
+name: deploy-argocd
+
+on:
+  workflow_dispatch:
+    inputs:
+      ocpAPI:
+        description: 'OpenShift API endpoint (eg. https://api.ocp-15.sandbox1900.opentlc.com:6443)'    
+        required: true   
+
+jobs:
+  deploy-argocd:
+    runs-on: macos-latest
+    env:
+      lcl_install_dir: argocd-deployment-${{ github.run_number }}
+
+    steps:
+      - name: "Checkout ${{ github.ref }}"
+        uses: actions/checkout@master
+        with:
+          ref: ${{ github.ref }}
+
+      - name: Install OpenShift CLI
+        uses: redhat-actions/oc-installer@v1
+
+      - name: Authenticate with OpenShift
+        uses: redhat-actions/oc-login@v1
+        with:
+          openshift_server_url: ${{ github.event.inputs.ocpAPI }}
+          openshift_username: ${{ secrets.OC_USER }}
+          openshift_password: ${{ secrets.OC_PASSWORD }}
+          insecure_skip_tls_verify: true
+
+      - name: Install ArgoCD
+        shell: bash
+        run: |
+          oc apply -f ./crd/argocd/argocd-sub.yaml
+
+          sleep 60
+          oc project openshift-gitops
+          TIMEOUT=0 
+          argo_status=$(oc get argocd -n openshift-gitops -o jsonpath='{.items[0].status.server}')
+          while [ "$argo_status" != "Running" ]; do
+            echo "ArgoCD operator still being deployed. Waiting one more minute..."
+            sleep 60
+
+            if [ $TIMEOUT -gt 15 ]; then #15 MINUTES TIMEOUT
+              echo "Timeout reached... Check the status of ArgoCD deployment on OpenShift."
+              exit 1
+            fi
+            TIMEOUT=$(($TIMEOUT+1))
+            argo_status=$(oc get argocd -n openshift-gitops -o jsonpath='{.items[0].status.server}')
+          done
+
+          argocd_url=$(oc get route openshift-gitops-server -n openshift-gitops -o jsonpath='{.spec.host}')
+
+          echo "ArgoCD is installed and available at \"https://$argocd_url\""
+          echo "Check the initial password for the admin user by running this command on your OpenShift cluster: \"oc extract secret/openshift-gitops-cluster -n openshift-gitops --to=-\""

--- a/.github/workflows/deploy-argocd.yml
+++ b/.github/workflows/deploy-argocd.yml
@@ -54,4 +54,4 @@ jobs:
           argocd_url=$(oc get route openshift-gitops-server -n openshift-gitops -o jsonpath='{.spec.host}')
 
           echo "ArgoCD is installed and available at \"https://$argocd_url\""
-          echo "Check the initial password for the admin user by running this command on your OpenShift cluster: \"oc extract secret/openshift-gitops-cluster -n openshift-gitops --to=-\""
+          echo "Check the initial password by running this command on your OpenShift cluster: \"oc extract secret/openshift-gitops-cluster -n openshift-gitops --to=-\""

--- a/.github/workflows/deploy-openshift.yml
+++ b/.github/workflows/deploy-openshift.yml
@@ -208,7 +208,6 @@ jobs:
           privkey_path: "${{github.workspace}}/certbot-config/live/${{ env.cert_name }}/privkey.pem"
         run: |
           export KUBECONFIG=$(pwd)/${{ env.lcl_install_dir }}/auth/kubeconfig
-          oc login -u ${{ secrets.OC_USER }} -p ${{ secrets.OC_PASSWORD }}
           fullchain="${{github.workspace}}/certbot-config/live/${{ env.cert_name }}/fullchain.pem"
           privkey="${{github.workspace}}/certbot-config/live/${{ env.cert_name }}/privkey.pem"
           oc create secret tls router-certs --cert=$fullchain --key=$privkey -n openshift-ingress

--- a/crd/argocd/argocd-sub.yaml
+++ b/crd/argocd/argocd-sub.yaml
@@ -1,0 +1,11 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: openshift-gitops-operator
+  namespace: openshift-operators
+spec:
+  channel: stable
+  installPlanApproval: Automatic
+  name: openshift-gitops-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace


### PR DESCRIPTION
The line `oc login ...` line on the `Apply ssl cert against OpenShift` step is causing a `Login failed (401 Unauthorized)` error. This line is not needed due to the `export KUBECONFIG` that exists right above it.

Here is an example of the error: https://github.com/giofontana/openshift-github-actions/runs/3244421378

I just removed that line and it is working fine, as you can see here: https://github.com/giofontana/openshift-github-actions/runs/3245089347
