### PR TITLE
Ability to change Master's number and flavor, to be able to deploy a single or 3 nodes cluster

### DIFF
--- a/.github/workflows/deploy-openshift.yml
+++ b/.github/workflows/deploy-openshift.yml
@@ -20,6 +20,14 @@ on:
         description: 'Cluster name prefix will get combined with the github run number'
         required: true
         default: 'ocp'
+      numMasters:
+        description: 'Number of masters to deploy on the cluster'
+        required: true
+        default: '3'        
+      mastersFlavor:
+        description: 'Masters default size'
+        required: true
+        default: 'm5.xlarge'     
       numWorkers:
         description: 'Number of workers to deploy on the cluster'
         required: true
@@ -109,6 +117,7 @@ jobs:
           export always_up=false
           export baseDomain=${{ github.event.inputs.baseDomain }}
           export numMasters=${{ env.numMasters }}
+          export mastersFlavor=${{ github.event.inputs.mastersFlavor }}          
           export numWorkers=${{ github.event.inputs.numWorkers }}
           export workersFlavor=${{ github.event.inputs.workersFlavor }}
           export hostPrefix=${{ env.hostPrefix }}

--- a/.github/workflows/deploy-openshift.yml
+++ b/.github/workflows/deploy-openshift.yml
@@ -47,7 +47,6 @@ jobs:
     env:
       lcl_install_dir: ${{ github.event.inputs.clusterNamePrefix }}-${{ github.run_number }}
       kubeconfig_path: "${{github.workspace}}/${{ github.event.inputs.clusterNamePrefix }}-${{ github.run_number }}/auth/kubeconfig"
-      numMasters: 3
       hostPrefix: '23'
       cidrClusterNetwork: '10.128.0.0/14'
       serviceNetwork: '172.30.0.0/16'
@@ -116,7 +115,7 @@ jobs:
           export delete_by=NEVER
           export always_up=false
           export baseDomain=${{ github.event.inputs.baseDomain }}
-          export numMasters=${{ env.numMasters }}
+          export numMasters=${{ github.event.inputs.numMasters }}
           export mastersFlavor=${{ github.event.inputs.mastersFlavor }}          
           export numWorkers=${{ github.event.inputs.numWorkers }}
           export workersFlavor=${{ github.event.inputs.workersFlavor }}

--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ To populate the Actions on your fork, they must be enabled.
 - SSH keys are generated, keys are sent to the S3 storage bucket.
 - The OpenShift cluster certificate, by default will encrypt traffic.  However it is not signed by a CA so it will appear insecure in the browser.  If you check the cert on [SSL checker](https://www.sslshopper.com/ssl-checker.html), it will show secure until the very end of the chain by default.  This job will finish securing the certificate by using Let's Encrypt via the route53 plugin.
 
+_NOTE:_ It is possible to deploy a single node cluster if you set the number of masters to 1 and workers for 0.
+
 #### For use with RHPDS Open Environments
 
 Please see the e-mail you received to set the following:

--- a/install-configs/install-config-template.yaml
+++ b/install-configs/install-config-template.yaml
@@ -12,7 +12,9 @@ controlPlane:
   architecture: amd64
   hyperthreading: Enabled
   name: master
-  platform: {}
+  platform: 
+    aws:
+      type: ${mastersFlavor}
   replicas: ${numMasters}
 metadata:
   creationTimestamp: null


### PR DESCRIPTION
Added the Master's number and flavor parameters to allow a user to deploy a single or 3 nodes cluster. 

Tested and it worked properly: https://github.com/giofontana/openshift-github-actions/runs/3668946958